### PR TITLE
Fix typo in UnlockManager comment

### DIFF
--- a/UnlockNexus/UnlockManager.cs
+++ b/UnlockNexus/UnlockManager.cs
@@ -79,7 +79,7 @@ namespace UnlockNexus
                 // Collapse Of Time
                 case UnlockKeys.CollapseOfTime:
                     return PerfectResonanceScore;
-                // Chjronicle Archives
+                // Chronicle Archives
                 case UnlockKeys.ChronicleArchives:
                     return EntropyTierSaveData >= 4;
                 case UnlockKeys.TemporalRifts:


### PR DESCRIPTION
## Summary
- fix a small typo in `UnlockManager`

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_6840146ac2f0832e881a77870e9207f1