### PR TITLE
Fix typo in collapse of time button label

### DIFF
--- a/LayerSwitcher.cs
+++ b/LayerSwitcher.cs
@@ -69,7 +69,7 @@ public class LayerSwitcher : MonoBehaviour
         SetTab(Tab.RealmOfResearch, false);
     }
 
-    [Button("-2 The Collapse of TIme")]
+    [Button("-2 The Collapse of Time")]
     public void SetLayerMinusFive()
     {
         SetTab(Tab.CollapseOfTime, false);


### PR DESCRIPTION
## Summary
- fix typo in the button label for Collapse of Time

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840145eec08832e931b1aaaf3b626af