### PR TITLE
Fix upgrade manager disable event unsubscribe

### DIFF
--- a/UpgradeSystem/UpgradeManager.cs
+++ b/UpgradeSystem/UpgradeManager.cs
@@ -37,6 +37,7 @@ namespace UpgradeSystem
 
         private void OnDisable()
         {
+            EventHandler.OnResetData -= ResetAllUpgrades;
             ClearAllUpgradesFromEntities();
         }
 


### PR DESCRIPTION
## Summary
- unsubscribe from `OnResetData` when the upgrade manager is disabled

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6840144d97c8832eb76d49e2d4ac9fa9