### PR TITLE
Fix IDS minigame loading

### DIFF
--- a/ChronicleArchivesNamespace/IdleDysonSwarm/IdsScriptables/IdsBuildingData.cs
+++ b/ChronicleArchivesNamespace/IdleDysonSwarm/IdsScriptables/IdsBuildingData.cs
@@ -51,6 +51,7 @@ namespace ChronicleArchivesNamespace.IdleDysonSwarm.IdsScriptables
             EventHandler.OnLoadData += LoadBuildingData;
             EventHandler.OnResetData += ResetBuildingData;
             IdsEvents.Infinity += ResetBuildingData;
+            LoadBuildingData();
         }
 
         private void OnDisable()


### PR DESCRIPTION
## Summary
- revert unintended null check in `IdsProductionManager`
- ensure `IdsBuildingData` loads save data when its GameObject is enabled

## Testing
- ❌ `dotnet build` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_684027bc7068832e93de8f1a0cb2eda4